### PR TITLE
Prepares for v0.1.0 release and upgrades dokka version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "org.partiql"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.0"
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 repositories {


### PR DESCRIPTION
Removes `SNAPSHOT` from gradle ahead of maven release. Upgrades dokka to 1.4.30 since the existing version was incompatible with Gradle 7. Further details on the dokka migration can be found [here](https://github.com/Kotlin/dokka/blob/master/runners/gradle-plugin/MIGRATION.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
