### PR TITLE
Prepare v0.1.1-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "org.partiql"
-version = "0.1.0"
+version = "0.1.1-SNAPSHOT"
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 repositories {


### PR DESCRIPTION
Bumps minor version to `v0.1.1` and appends `-SNAPSHOT`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
