### PR TITLE
Update dependencies ion-element to v1.0.0 and partiql-ir-generator to v0.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,16 +38,16 @@ java {
 
 kotlin {
     sourceSets {
-        main.kotlin.srcDirs = ["src", "src/org/partiql/ionschema/build/generated-src/pig/"]
+        main.kotlin.srcDirs = ["src", "build/generated/pig/main/kotlin"]
         test.kotlin.srcDirs = ["test"]
     }
 }
 
 dependencies {
     api 'com.amazon.ion:ion-java:1.8.0'
-    api 'com.amazon.ion:ion-element:0.2.0'
+    api 'com.amazon.ion:ion-element:1.0.0'
     api 'com.amazon.ion:ion-schema-kotlin:1.2.1'
-    api 'org.partiql:partiql-ir-generator-runtime:0.4.0'
+    api 'org.partiql:partiql-ir-generator-runtime:0.5.1'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
@@ -94,20 +94,18 @@ import org.partiql.pig.cmdline.Command
 import org.partiql.pig.cmdline.TargetLanguage
 import org.partiql.pig.errors.PigException
 
-def islDomainFile = 'isl-model.kt'
-
 task generatePigDomains {
     group = "code generation"
 
     // TODO: in the future, utilize the API created as part of this ticket:
     // https://github.com/partiql/partiql-ir-generator/issues/5
 
-    project.file("${projectDir}/src/org/partiql/ionschema/build/generated-src/pig/").mkdirs()
+    project.file("${projectDir}/build/generated/pig/main/kotlin/org/partiql/ionschema/model/").mkdirs()
 
     def typeUniverse = new File(projectDir, "src/org/partiql/ionschema/model/isl.ion")
-    def outputFile = new File(projectDir, "src/org/partiql/ionschema/build/generated-src/pig/$islDomainFile")
-    def targetLanguage = new TargetLanguage.Kotlin("org.partiql.ionschema.model")
-    def cmd = new Command.Generate(typeUniverse, outputFile, targetLanguage)
+    def outputFile = new File(projectDir, "build/generated/pig/main/kotlin/org/partiql/ionschema/model/")
+    def targetLanguage = new TargetLanguage.Kotlin("org.partiql.ionschema.model", outputFile, null)
+    def cmd = new Command.Generate(typeUniverse, targetLanguage)
 
     // TODO:
     // Tell gradle about the input and output of this task so that it only invokes pig when
@@ -127,7 +125,8 @@ compileKotlin.dependsOn generatePigDomains
 
 ktlint {
     filter {
-        exclude("**/$islDomainFile")
+        // Excludes any code in the build directory, which is assumed to be generated.
+        exclude { projectDir.toURI().relativize(it.file.toURI()).path.startsWith("build") }
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,5 +5,5 @@ repositories {
 
 dependencies {
     // Adding this dependency here in buildSrc allows PIG to be invoked by the project at build time.
-    implementation 'org.partiql:partiql-ir-generator:0.4.0'
+    implementation 'org.partiql:partiql-ir-generator:0.5.1'
 }

--- a/src/org/partiql/ionschema/model/ToIsl.kt
+++ b/src/org/partiql/ionschema/model/ToIsl.kt
@@ -9,7 +9,6 @@ import com.amazon.ionelement.api.ionListOf
 import com.amazon.ionelement.api.ionString
 import com.amazon.ionelement.api.ionStructOf
 import com.amazon.ionelement.api.ionSymbol
-import com.amazon.ionelement.api.withAnnotations
 
 private val MAX = ionSymbol("max")
 private val MIN = ionSymbol("min")

--- a/src/org/partiql/ionschema/parser/IonSchemaParser.kt
+++ b/src/org/partiql/ionschema/parser/IonSchemaParser.kt
@@ -10,7 +10,6 @@ import com.amazon.ionelement.api.SymbolElement
 import com.amazon.ionelement.api.TimestampElement
 import com.amazon.ionelement.api.ionBool
 import com.amazon.ionelement.api.ionSymbol
-import com.amazon.ionelement.api.withoutAnnotations
 import org.partiql.ionschema.model.IonSchemaModel
 import org.partiql.pig.runtime.SymbolPrimitive
 
@@ -328,7 +327,7 @@ internal fun parseTimestampValuesExtent(elem: AnyElement) =
             else -> parseError(elem, Error.InvalidTimestampExtent)
         }
         is TimestampElement -> if (elem.allowSingleAnnotation("exclusive")) {
-            IonSchemaModel.build { exclusiveTsValue(elem.withoutAnnotations()) }
+            IonSchemaModel.build { exclusiveTsValue((elem as TimestampElement).withoutAnnotations()) }
         } else {
             IonSchemaModel.build { inclusiveTsValue(elem) }
         }


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Updates to use the stable release of `ion-element`, and consequently, the pig runtime must also be updated.

While I was at it, I moved the generated code to the build directory, since it is technically a build artifact that is produced from the ISL type domain file.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
