### PR TITLE
Changes Java compatibility to JDK 1.8 and adds JDK 17 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          java: [8, 9, 10, 11]
+          java: [8, 11, 17]
 
       steps:
         - name: Check out code 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 plugins {
     id 'java-library'
-    id 'org.jetbrains.kotlin.jvm' version '1.4.0'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.31'
     id 'maven-publish'
     id 'signing'
     id 'org.jetbrains.dokka' version '1.4.30'
@@ -24,6 +24,8 @@ repositories {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         jvmTarget = "1.8"
+        apiVersion = "1.4"
+        languageVersion = "1.4"
     }
 }
 
@@ -34,6 +36,8 @@ java {
         test.java.srcDirs = ["test"]
         test.resources.srcDirs = ["test-resources"]
     }
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 kotlin {


### PR DESCRIPTION

**Issue #, if available:**

None, but necessary to unblock https://github.com/partiql/partiql-lang-kotlin/pull/725

**Description of changes:**

* Upgrades Kotlin Gradle plugin to 1.5.31.
* Adds language/lib target to Kotlin 1.4 to ensure compatibility.
* Adds Java 8 compatibility to align with Kotlin. _This is the critical part that is necessary to unblock the other PR. The rest is mostly just housekeeping._
* Adds CI support for JDK 17 and removes non-LTS releases that are past EOL.


_I think this change is backwards compatible, but you should double check before deciding whether to release this as `0.2.1` or `0.3.0`._


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
